### PR TITLE
RangeError: offset is out of bounds (64KB+)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const assert = require('nanoassert')
-const { exports: murmur3, memory } = require('./murmur3')()
+const mod = require('./murmur3')()
 
 /**
  * Murmur3 hash
@@ -10,6 +10,11 @@ const { exports: murmur3, memory } = require('./murmur3')()
 module.exports = function murmur3Hash (buf, seed) {
   assert(buf instanceof Uint8Array, 'buf must be Buffer or Uint8Array')
   assert(seed >>> 0 < 0xffffffff + 1, 'seed must be a valid 32-bit integer')
-  memory.set(buf, 0)
-  return murmur3.hash(0, buf.byteLength, seed)
+
+  if (buf.byteLength > mod.memory.byteLength) {
+    mod.realloc(buf.byteLength)
+  }
+
+  mod.memory.set(buf, 0)
+  return mod.exports.hash(0, buf.byteLength, seed)
 }

--- a/test.js
+++ b/test.js
@@ -40,5 +40,9 @@ test('fixtures', function (assert) {
   assert.equal(murmur3(Buffer.from('Hello world')) >>> 0, 2911983372, 'Hello world')
   assert.equal(murmur3(Buffer.from('Hello world!')) >>> 0, 1652231212, 'Hello world!')
 
+  assert.equal(murmur3(Buffer.alloc(65535)) >>> 0, 2878094072, '65535 bytes')
+  assert.equal(murmur3(Buffer.alloc(65536)) >>> 0, 2603582549, '65536 bytes')
+  assert.equal(murmur3(Buffer.alloc(65537)) >>> 0, 1955252949, '65537 bytes')
+
   assert.end()
 })


### PR DESCRIPTION
It fails for input data larger than 64KB.

The patch performs `realloc()` automatically at the case.

Without the patch, the following test fails:

```js
  assert.equal(murmur3(Buffer.alloc(65537)) >>> 0, 1955252949, '65537 bytes')
```

```
./index.js:18
  mod.memory.set(buf, 0)
             ^

RangeError: offset is out of bounds
    at Uint8Array.set (<anonymous>)
    at murmur3Hash (./index.js:18:14)
    at Test.<anonymous> (./test.js:45:16)
    at Test.bound [as _cb] (./node_modules/tape/lib/test.js:88:32)
    at Test.run (./node_modules/tape/lib/test.js:105:10)
    at Test.bound [as run] (./node_modules/tape/lib/test.js:88:32)
    at Immediate.next (./node_modules/tape/lib/results.js:82:19)
    at processImmediate (node:internal/timers:464:21)
```

Note that there are no way to decrease memory consumption after `realloc`-ed.
